### PR TITLE
Correct initial dynamic table limit

### DIFF
--- a/lib/HTTP/HPACK.rakumod
+++ b/lib/HTTP/HPACK.rakumod
@@ -228,7 +228,7 @@ role HTTP::HPACK::Tables {
     my constant STATIC_ELEMS = STATIC_TABLE.elems;
 
     has @!dynamic-table;
-    has Int $.dynamic-table-limit = 512;
+    has Int $.dynamic-table-limit = 4096;
 
     method set-dynamic-table-limit(Int $new-size) {
         $!dynamic-table-limit = $new-size;


### PR DESCRIPTION
The correct value is given in rfc9113 paragraph 4.3.1:

    When a connection is established, the dynamic table size for the
    HPACK decoder and encoder at both endpoints starts at 4,096 bytes,
    the initial value of the SETTINGS_HEADER_TABLE_SIZE setting.

This fixes "Header table index 82 out of range" errors ocurring when using Cro::HTTP::Client with HTTP2 and multiple requests per connection.

fixes croservices/cro-http#122
fixes croservices/cro-http#156