### PR TITLE
Resolved bug on Windows

### DIFF
--- a/lib/HTTP/HPACK.rakumod
+++ b/lib/HTTP/HPACK.rakumod
@@ -376,7 +376,8 @@ class HTTP::HPACK::Decoder does HTTP::HPACK::Tables {
 class HTTP::HPACK::Encoder does HTTP::HPACK::Tables {
     has Bool $.huffman = False;
 
-    method encode-headers(@headers where all(@headers) ~~ HTTP::HPACK::Header) returns Blob {
+    # Implements constraint: `@headers where all(@headers) ~~ HTTP::HPACK::Header` but in a way compatible with the windows all regression.
+    method encode-headers(@headers where [and] @headers.map(* ~~ HTTP::HPACK::Header)) returns Blob {
         my $result = Buf.new;
         for @headers -> $header {
             # Search tables for a matching entry.

--- a/t/encoder.rakutest
+++ b/t/encoder.rakutest
@@ -1,0 +1,29 @@
+use Test;
+use HTTP::HPACK :internal;
+
+#
+# Tests for the HTTP::HPACK::Encoder module.
+#
+# The majority of specification testing happens in examples.
+# The following tests target the API of the module.
+#
+
+sub header($name, $value, $indexing = HTTP::HPACK::Indexing::Indexed) {
+    HTTP::HPACK::Header.new(:$name, :$value, :$indexing)
+}
+
+# Test custom signature behavior for the encode-headers method.
+ok HTTP::HPACK::Encoder.new.encode-headers([
+    header('custom-key', 'custom-header'),
+    header('custom-key2', 'custom-header2')
+    ]).so,
+'Encoder.encode-headers accepts array of HTTP::HPACK::Header objects';
+
+dies-ok {
+    HTTP::HPACK::Encoder.new.encode-headers(
+    [ "Not a header", "me neither" ]),
+    Buf.new(0x40, 0x0a, 0x63)
+},
+'Encoder.encode-headers throws on bad input';
+
+done-testing


### PR DESCRIPTION
Windows platform builds of raku post mid-late 2024 are exhibiting a regression  in the behaviour of all in comparisons. This patch replaces code in a type constraint check that fails under this regression. Thic change also adds a new test file to cover API related behaviors of the module. The parameter constraint for encode-headers has been added to the API test to ensure there are no unintentional changes to this in the future.